### PR TITLE
Provider Update and Move to Autopilot and Artifact Registry

### DIFF
--- a/client/kubernetes-manifests/guacamole-client.deployment.yaml
+++ b/client/kubernetes-manifests/guacamole-client.deployment.yaml
@@ -52,10 +52,11 @@
                 name: db-user-pass
           resources:
             limits:
-              memory: 512Mi
+              cpu: 1000m
+              memory: 2000Mi
             requests:
-              cpu: 100m
-              memory: 200Mi
+              cpu: 1000m
+              memory: 2000Mi
           ports:
           - containerPort: 8080
             name: serving-port

--- a/server/kubernetes-manifests/guacamole-server.deployment.yaml
+++ b/server/kubernetes-manifests/guacamole-server.deployment.yaml
@@ -43,10 +43,11 @@
           imagePullPolicy: IfNotPresent
           resources:
             limits:
-              memory: 170Mi
+              cpu: 250m
+              memory: 512Mi
             requests:
-              cpu: 100m
-              memory: 70Mi
+              cpu: 250m
+              memory: 512Mi
           ports:
           - containerPort: 4822
             name: guacd

--- a/tf-infra/artifactrepo.tf
+++ b/tf-infra/artifactrepo.tf
@@ -18,6 +18,7 @@ resource "google_artifact_registry_repository" "guac-repo" {
   repository_id = "guac-repo"
   description   = "Docker Repository For IAP Enabled Guacamole"
   format        = "DOCKER"
+  depends_on = [module.project-services]
 }
 
 resource "google_artifact_registry_repository_iam_member" "artifactregistry-iam" {

--- a/tf-infra/artifactrepo.tf
+++ b/tf-infra/artifactrepo.tf
@@ -1,0 +1,29 @@
+# 
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_artifact_registry_repository" "guac-repo" {
+  location      = var.region
+  repository_id = "guac-repo"
+  description   = "Docker Repository For IAP Enabled Guacamole"
+  format        = "DOCKER"
+}
+
+resource "google_artifact_registry_repository_iam_member" "artifactregistry-iam" {
+  project = google_artifact_registry_repository.guac-repo.project
+  location = google_artifact_registry_repository.guac-repo.location
+  repository = google_artifact_registry_repository.guac-repo.name
+  role = "roles/artifactregistry.reader"
+  member = "serviceAccount:${data.google_compute_default_service_account.default.email}"
+}

--- a/tf-infra/cloudsql.tf
+++ b/tf-infra/cloudsql.tf
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 resource "google_service_networking_connection" "private_vpc_connection" {
-  provider                = google-beta
+  provider                = google
   network                 = google_compute_network.vpc.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_address.name]

--- a/tf-infra/compute.tf
+++ b/tf-infra/compute.tf
@@ -41,7 +41,7 @@ resource "google_compute_router_nat" "nat" {
 }
 
 resource "google_compute_global_address" "private_ip_address" {
-  provider      = google-beta
+  provider      = google
   name          = "private-ip-address"
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"

--- a/tf-infra/gke.tf
+++ b/tf-infra/gke.tf
@@ -14,22 +14,12 @@
 # limitations under the License.
 
 resource "google_container_cluster" "gke" {
-  provider           = google-beta
+  provider           = google
   name               = "guacamole-gke"
   location           = var.region
-  initial_node_count = 1
   networking_mode    = "VPC_NATIVE"
   network            = google_compute_network.vpc.id
   subnetwork         = google_compute_subnetwork.subnet.name
-
-  master_auth {
-    username = ""
-    password = ""
-  }
-
-  workload_identity_config {
-    identity_namespace = "${var.project_id}.svc.id.goog"
-  }
 
   private_cluster_config {
     enable_private_nodes    = true
@@ -37,29 +27,7 @@ resource "google_container_cluster" "gke" {
     master_ipv4_cidr_block  = var.nwr_master_node
   }
 
-  enable_shielded_nodes = true
-
-  node_config {
-    machine_type = "e2-standard-2"
-
-    workload_metadata_config {
-      node_metadata = "GKE_METADATA_SERVER"
-    }
-
-    metadata = {
-      enable_oslogin = true
-    }
-
-    shielded_instance_config {
-      enable_secure_boot = true
-    }
-
-    service_account = google_service_account.svc-gke-node.email
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/cloud-platform"
-    ]
-
-  }
+  enable_autopilot = true
 
   ip_allocation_policy {}
 }

--- a/tf-infra/gke.tf
+++ b/tf-infra/gke.tf
@@ -29,6 +29,13 @@ resource "google_container_cluster" "gke" {
 
   enable_autopilot = true
 
+  #When using TF provider <4.80, need to explicitly define CLOUD_DNS as cluster_dns per b/295958728
+  dns_config {
+    cluster_dns        = "CLOUD_DNS"
+    cluster_dns_domain = "cluster.local"
+    cluster_dns_scope  = "CLUSTER_SCOPE"
+  }
+
   ip_allocation_policy {}
 }
 

--- a/tf-infra/iam.tf
+++ b/tf-infra/iam.tf
@@ -47,8 +47,6 @@ resource "google_project_iam_custom_role" "iap-jwt-verify-role" {
   permissions = ["compute.backendServices.get"]
 }
 
-
-
 resource "google_service_account" "svc-gke-node" {
   account_id  = "svc-gke-node"
   description = "GKE Node Service Account"
@@ -61,5 +59,3 @@ resource "google_project_iam_member" "svc-gke-node-iam" {
   member  = "serviceAccount:${google_service_account.svc-gke-node.email}"
   role    = each.value
 }
-
-

--- a/tf-infra/main.tf
+++ b/tf-infra/main.tf
@@ -19,11 +19,11 @@ provider "google" {
   project = var.project_id
 }
 
-provider "google-beta" {
-  region  = var.region
-  zone    = var.zone
-  project = var.project_id
-}
+#provider "google-beta" {
+#  region  = var.region
+#  zone    = var.zone
+#  project = var.project_id
+#}
 
 provider "null" {
 }
@@ -93,15 +93,17 @@ resource "google_iap_client" "project_client" {
   brand        = google_iap_brand.project_brand.name
 }
 
-resource "google_container_registry" "registry" {
-  depends_on = [module.project-services]
-}
+#resource "google_container_registry" "registry" {
+#  depends_on = [module.project-services]
+#}
 
-resource "google_storage_bucket_iam_member" "gke-read-cloudrepo" {
-  bucket = google_container_registry.registry.id
-  role   = "roles/storage.objectViewer"
-  member = "serviceAccount:${google_service_account.svc-gke-node.email}"
-}
+#resource "google_storage_bucket_iam_member" "gke-read-cloudrepo" {
+#  bucket = google_container_registry.registry.id
+#  role   = "roles/storage.objectViewer"
+#  member = "serviceAccount:${google_service_account.svc-gke-node.email}"
+#}
+
+data "google_compute_default_service_account" "default" {}
 
 data "google_client_openid_userinfo" "me" {}
 

--- a/tf-infra/variables.tf
+++ b/tf-infra/variables.tf
@@ -46,12 +46,15 @@ variable "nwr_master_node" {
 
 variable "required_apis" {
   description = "Google Cloud APIs required by this tutorial."
-  default = ["compute.googleapis.com",
+  default = ["cloudresourcemanager.googleapis.com", 
+    "serviceusage.googleapis.com",
+    "compute.googleapis.com",
     "container.googleapis.com",
-    "containerregistry.googleapis.com",
+    #"containerregistry.googleapis.com",
     "cloudbuild.googleapis.com",
     "servicenetworking.googleapis.com",
     "iap.googleapis.com",
+    "artifactregistry.googleapis.com",
     "sqladmin.googleapis.com",
   "stackdriver.googleapis.com"]
 }

--- a/tf-infra/versions.tf
+++ b/tf-infra/versions.tf
@@ -19,13 +19,13 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "3.67.0"
+      version = "4.58.0"
     }
 
-    google-beta = {
-      source  = "hashicorp/google-beta"
-      version = "3.67.0"
-    }
+    #google-beta = {
+    #  source  = "hashicorp/google-beta"
+    # version = "4.58.0"
+    #}
 
     external = {
       source  = "hashicorp/external"

--- a/tf-k8s/versions.tf
+++ b/tf-k8s/versions.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
-      version = "3.67.0"
+      version = "4.58.0"
     }
 
     kubernetes = {


### PR DESCRIPTION
Updated multiple files to support the following major updates:

- Update Google Terraform provider to `4.58.0`
- Remove all references to `google-beta` Terraform provider
- Created new Artifact Registry resource and associated IAM bindings, as Container Registry will be deprecated in May 2024.
- GKE Standard -> GKE Autopilot
- Updated resource `requests` and `limits` for both Guacamole deployments for both stable deployment and appropriate resource requirements/ratios for GKE Autopilot.