### PR TITLE
Google provider update to latest version (5.6)

### DIFF
--- a/tf-infra/gke.tf
+++ b/tf-infra/gke.tf
@@ -29,12 +29,13 @@ resource "google_container_cluster" "gke" {
 
   enable_autopilot = true
 
+  #Updated to TF Provider 5.6, no longer need to explicityly define the below block, as it's the default now
   #When using TF provider <4.80, need to explicitly define CLOUD_DNS as cluster_dns per b/295958728
-  dns_config {
-    cluster_dns        = "CLOUD_DNS"
-    cluster_dns_domain = "cluster.local"
-    cluster_dns_scope  = "CLUSTER_SCOPE"
-  }
+  #dns_config {
+  #  cluster_dns        = "CLOUD_DNS"
+  #  cluster_dns_domain = "cluster.local"
+  #  cluster_dns_scope  = "CLUSTER_SCOPE"
+  #}
 
   ip_allocation_policy {}
 }

--- a/tf-infra/versions.tf
+++ b/tf-infra/versions.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "4.58.0"
+      version = "5.6.0"
     }
 
     #google-beta = {

--- a/tf-k8s/versions.tf
+++ b/tf-k8s/versions.tf
@@ -19,12 +19,12 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
-      version = "4.58.0"
+      version = "5.6.0"
     }
 
     kubernetes = {
       source = "hashicorp/kubernetes"
-      version = "2.13.0"
+      version = "2.23.0"
     }
   }  
 }


### PR DESCRIPTION
Updated TF providers to latest versions. Also removed redundant code block from gke.tf for cluster dns definition, now  redundant.