### PR TITLE
Uplift to Guacamole 1.5.5 and bump components

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -16,7 +16,7 @@
 ARG CLIENT_IMAGE=guacamole-client:latest
 
 # Use official maven image for the build
-FROM maven:3-jdk-8 AS builder
+FROM maven:3-eclipse-temurin-21 AS builder
 
 # Use args to build radius auth extension such as
 # `--build-arg BUILD_PROFILE=lgpl-extensions`

--- a/client/extensions/guacamole-auth-googleiap/pom.xml
+++ b/client/extensions/guacamole-auth-googleiap/pom.xml
@@ -165,7 +165,7 @@ limitations under the License.
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
-            <version>9.31</version>
+	    <version>9.37.2</version>
         </dependency>
 
         <dependency>

--- a/server/kubernetes-manifests/guacamole-server.deployment.yaml
+++ b/server/kubernetes-manifests/guacamole-server.deployment.yaml
@@ -39,7 +39,7 @@
       spec:
         containers:
         - name: guacamole-server
-          image: docker.io/guacamole/guacd:1.5.2
+          image: docker.io/guacamole/guacd:1.5.5
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/tf-infra/cloudsql.tf
+++ b/tf-infra/cloudsql.tf
@@ -27,7 +27,7 @@ resource "google_sql_database_instance" "guacamole-mysql" {
     See https://cloud.google.com/sql/docs/mysql/delete-instance for details.
     */
   name             = "${var.db_name}-${random_id.suffix.hex}"
-  database_version = "MYSQL_5_7"
+  database_version = "MYSQL_8_0"
   region           = var.region
 
   depends_on = [google_service_networking_connection.private_vpc_connection]

--- a/tf-infra/compute.tf
+++ b/tf-infra/compute.tf
@@ -64,7 +64,7 @@ resource "google_compute_instance" "db-management" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-10"
+      image = "debian-cloud/debian-12"
     }
   }
 

--- a/tf-k8s/versions.tf
+++ b/tf-k8s/versions.tf
@@ -19,12 +19,12 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
-      version = "5.6.0"
+      version = ">=5.6.0"
     }
 
     kubernetes = {
       source = "hashicorp/kubernetes"
-      version = "2.23.0"
+      version = ">=2.23.0"
     }
   }  
 }


### PR DESCRIPTION
Uplift:

Guacamole 1.5.5
Cloud SQL MySQL 8.0
Debian 12
Terraform modules
Java dependencies